### PR TITLE
Updated-docker-to-accept-only-port-443-requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker compose up -d --build
 ```
 Navigate to the application on `localhost:8000`
 
-If you have traefik ensure that traefik is running first then visit http://chatroom.kiirumaina.test
+If you have traefik ensure that traefik is running first then visit https://chatroom.docker.localhost
 
 
 ### Running the App on PC

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,17 +8,18 @@
 # database or a cache. For examples, see the Awesome Compose repository:
 # https://github.com/docker/awesome-compose
 services:
-  chatroom-server:
+  chat-room:
     build:
       context: .
-    container_name: studybud
+    container_name: chat-room
+    restart: unless-stopped
     networks:
       - traefik
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.django.rule=Host(`chatroom.kiirumaina.test`)"
+      - "traefik.http.routers.django.rule=Host(`chatroom.docker.localhost`)"
       - "traefik.http.services.django.loadbalancer.server.port=8000"
-      - "traefik.http.routers.django.entrypoints=web"
+      - "traefik.http.routers.django.entrypoints=websecure"
 networks:
   traefik:
     external: true

--- a/studybud/settings.py
+++ b/studybud/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-3#av2c6nptlbbb6^muqkchu&fe3wv&n$t2+g$v!ir-f5%doocb
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["0.0.0.0", "127.0.0.1", "chatroom.kiirumaina.com", "chatroom.kiirumaina.test"]
+ALLOWED_HOSTS = ["0.0.0.0", "127.0.0.1", "chatroom.kiirumaina.com", "chatroom.docker.localhost"]
 
 
 # Application definition


### PR DESCRIPTION
Updated Docker to only accept request for port 443 on container running with traefik